### PR TITLE
Does Typing Only Pytest work for you?

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ pip install -r requirements.txt
 pre-commit install
 ```
 
-You can run the unit tests by running `python3 -m pytest tests` from the root of the project directory.
+You can run the unit tests by running `pytest` from the root of the project directory.


### PR DESCRIPTION
It does for me. If so, it might be nice to simplify the command for testing this project to simply 'pytest`.

Also, when you run pytest do you get Deprecation Warnings that seem to come from something upstream in bs4? We could try to fix that upstream. It looks simple to fix. (Famous last words.)