### PR TITLE
Use string, not text, for bs4 function arg

### DIFF
--- a/funderfinder/utils/github_sources.py
+++ b/funderfinder/utils/github_sources.py
@@ -31,7 +31,7 @@ def get_funding_sources(repo: str) -> list:
     """
     page = requests.get(f"https://github.com/{repo}")
     soup = bs4.BeautifulSoup(page.text, features="html.parser")
-    sponsor_elems = soup(text="Sponsor this project")
+    sponsor_elems = soup(string="Sponsor this project")
     if len(sponsor_elems) == 0:
         logging.warning(f"No sponsors found for {repo}")
         return []


### PR DESCRIPTION
Closes #17
 
This change eliminates a deprecation warning that was appearing in the CI.

I had initially thought that a method *inside* beautiful soup was deprecated. Actually, the `funder-finder` code was using a deprecated beautiful soup method. This should fix the deprecation warning that showing up in the CI without impacting functionality.

Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>