### PR TITLE
Add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status](https://github.com/georgetown-cset/funder-finder/actions/workflows/main.yml/badge.svg)
+
 # Funder Finder
 
 This project allows you to retrieve funding information for a GitHub repository of interest to you. Current


### PR DESCRIPTION
Fix #40

Add a build status badge to help maintainers and users know current status of build, that is, is the latest build passing or failing.