### PR TITLE
Check "Sponsor this project" links for github sponsors

### DIFF
--- a/funderfinder/sources/github_sponsors.py
+++ b/funderfinder/sources/github_sponsors.py
@@ -181,7 +181,8 @@ class GitHubSponsorsFinder(Finder):
         """
         sources = get_funding_sources(repo)
         for source in sources:
-            if "github.com" not in source:
+            # Check whether we're looking at a github sponsors link
+            if "github.com/sponsors" not in source:
                 continue
             # Given a sponsor page link like https://github.com/sponsors/babel, get "babel"
             sponsored_entity = source.strip("/").split("/")[-1]

--- a/funderfinder/sources/github_sponsors.py
+++ b/funderfinder/sources/github_sponsors.py
@@ -171,8 +171,9 @@ class GitHubSponsorsFinder(Finder):
         self, repo: str, num_org_funders: int, top_contribs: list
     ) -> bool:
         """
-        Retrieves funding sources listed under "sponsor this project", and filters to those
-        that are (a) github sponsors and (b) have not already been retrieved
+        Checks links listed under "sponsor this project", and filters to those
+        that are (a) github sponsor links and (b) are not organizational or user pages we've already detected.
+        Returns True if any such sponsor links are present.
         :param repo: GitHub repo slug
         :param num_org_funders: Number of organizational funders this project has
         :param top_contribs: List of top contributors

--- a/funderfinder/sources/github_sponsors.py
+++ b/funderfinder/sources/github_sponsors.py
@@ -57,7 +57,7 @@ class GitHubSponsorsFinder(Finder):
         """
         Retrieves GitHub sponsors statistics for a GitHub organization.
         :param org: identifier for the GitHub organization
-        :return: Dict of funding stats
+        :return: Count of funding stats
         """
         stats = self.get_gh_org_funding_json(org)
         count = (

--- a/tests/sources/test_github_sponsors.py
+++ b/tests/sources/test_github_sponsors.py
@@ -39,9 +39,13 @@ class TestGithubSponsors(unittest.TestCase):
         self.assertEqual(got, 15)
 
     def test_flux_has_sponsor_this_project(self):
+        # This test may fail in the future if Flux GitHub Sponsors get referenced in the Readme, or if
+        # sponsors are removed from the "Sponsor this project" list
         self.assertTrue(self.finder.has_sponsor_this_project("FluxML/Flux.jl", 0, []))
 
     def test_babel_has_no_sponsor_this_project(self):
+        # This test may fail in the future if new Babel GitHub Sponsors are added to the "Sponsor this project"
+        # list, or existing GitHub Sponsors are removed from the readme but left in the "Sponsor this project" list
         self.assertFalse(self.finder.has_sponsor_this_project("babel/babel", 1, []))
 
     def test_funder_finder_has_no_sponsor_this_project(self):

--- a/tests/sources/test_github_sponsors.py
+++ b/tests/sources/test_github_sponsors.py
@@ -37,3 +37,14 @@ class TestGithubSponsors(unittest.TestCase):
 
         got = self.finder.parse_gh_user_gh_sponsors_json(test_json)
         self.assertEqual(got, 15)
+
+    def test_flux_has_sponsor_this_project(self):
+        self.assertTrue(self.finder.has_sponsor_this_project("FluxML/Flux.jl", 0, []))
+
+    def test_babel_has_no_sponsor_this_project(self):
+        self.assertFalse(self.finder.has_sponsor_this_project("babel/babel", 1, []))
+
+    def test_funder_finder_has_no_sponsor_this_project(self):
+        self.assertFalse(
+            self.finder.has_sponsor_this_project("georgetown-cset/funder-finder", 0, [])
+        )


### PR DESCRIPTION
Closes #15 

See what you think about this implementation. The idea is to, given a link to a github sponsors page listed under "Sponsor this Project", check whether the link corresponds to the project owner or one of the top contributors. If not, we add in a new record to the GitHub Sponsors funding sources with `funding_type` "sponsor_this_project"

(sorry for the huge delay in getting to this btw, we launched a [new product](https://almanac.eto.tech/) and a major new [feature](https://sciencemap.eto.tech/?all_subjects=computer+security&mode=summary) last week and was distracted for a while! Hope all's well on your end.)